### PR TITLE
Fix display of large extra data / transaction data

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
                 {% if(o.data.length > 0) { %}
                     <div class="blockinfo-body-row">
                         <label>Message </label>
-                        <span>{%=_formatTxData(o.data)%}</span>
+                        <span class="blockinfo-extra-data">{%=_formatTxData(o.data)%}</span>
                     </div>
                 {% } %}
                 <div class="blockinfo-body-row">

--- a/style.css
+++ b/style.css
@@ -551,6 +551,7 @@ hash {
 .blockinfo-body-row {
     margin: 0.75em 0;
     min-height: 1.4em;
+    overflow: auto;
 }
 
 .blockinfo-body-row label,
@@ -573,7 +574,7 @@ hash {
 }
 
 .blockinfo-extra-data {
-    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .blockinfo-transactions {


### PR DESCRIPTION
Long transaction data / extra data without any non-word characters (e.g. a long hex-encoded value) would overflow the infobox and be cut off.